### PR TITLE
Update apps to v0.6.0

### DIFF
--- a/mnist/params.json
+++ b/mnist/params.json
@@ -1,38 +1,113 @@
 {
-  "archiveSize": 500,
-  "archivingProbability": 0.01,
-  "doValidation": true,
-  "maxNbActionsPerEval": 500,
-  "maxNbEvaluationPerPolicy": 2000,
-  "nbGenerations": 200,
-  "nbIterationsPerPolicyEvaluation": 1,
-  "nbIterationsPerJob": 1,
-  "nbProgramConstant": 5,
-  "nbRegisters": 8,
-  "ratioDeletedRoots": 0.90,
-
-  "mutation": {
-    "tpg": {
-      "forceProgramBehaviorChangeOnMutation": true,
-      "maxInitOutgoingEdges": 3,
-      "maxOutgoingEdges": 5,
-      "nbActions": 10,
-      "nbRoots": 500,
-      "pEdgeAddition": 0.7,
-      "pEdgeDeletion": 0.7,
-      "pEdgeDestinationChange": 0.1,
-      "pEdgeDestinationIsAction": 0.5,
-      "pProgramMutation": 0.2
-    },
-    "prog": {
-      "maxConstValue": 10,
-      "maxProgramSize": 20,
-      "minConstValue": -10,
-      "pAdd": 0.5,
-      "pConstantMutation": 0.5,
-      "pDelete": 0.5,
-      "pMutate": 1.0,
-      "pSwap": 1.0,
-    }
-  }
+	// Number of recordings held in the Archive.
+	// "archiveSize" : 50, // Default value
+	"archiveSize" : 500,
+	// Probability of archiving the result of each Program execution.
+	// "archivingProbability" : 0.05, // Default value
+	"archivingProbability" : 0.01,
+	// Boolean used to activate an evaluation of the surviving roots in validation
+	// mode after the training at each generation.
+	// "doValidation" : false, // Default value
+	"doValidation" : true,
+	// Maximum number of actions performed on the learning environment during the
+	// each evaluation of a root.
+	// "maxNbActionsPerEval" : 1000, // Default value
+	"maxNbActionsPerEval" : 500,
+	// Maximum number of times a given root is evaluated.After this number is
+	// reached, possibly after several generations, the score of the root will be
+	// fixed, and no further evaluation will be done.
+	// "maxNbEvaluationPerPolicy" : 1000, // Default value
+	"maxNbEvaluationPerPolicy" : 2000,
+	"mutation" : 
+	{
+		"prog" : 
+		{
+			// Maximum constant value possible.
+			// "maxConstValue" : 100, // Default value
+			"maxConstValue" : 10,
+			// Maximum number of Line within the Program of the TPG.
+			// "maxProgramSize" : 96, // Default value
+			"maxProgramSize" : 20,
+			// Minimum constant value possible.
+			// "minConstValue" : -10, // Default value
+			"minConstValue" : -10,
+			// Probability of inserting a line in the Program.
+			// "pAdd" : 0.5, // Default value
+			"pAdd" : 0.5,
+			// Probability of each constant to be mutated.
+			// "pConstantMutation" : 0.5, // Default value
+			"pConstantMutation" : 0.5,
+			// Probability of deleting a line of the Program.
+			// "pDelete" : 0.5, // Default value
+			"pDelete" : 0.5,
+			// Probability of altering a line of the Program.
+			// "pMutate" : 1.0, // Default value
+			"pMutate" : 1.0,
+			// Probability of swapping two lines of the Program.
+			// "pSwap" : 1.0, // Default value
+			"pSwap" : 1.0
+		},
+		"tpg" : 
+		{
+			// When a Program is mutated, makes sure its behavior is no longer the same.
+			// "forceProgramBehaviorChangeOnMutation" : false, // Default value
+			"forceProgramBehaviorChangeOnMutation" : true,
+			// Maximum number of TPGEdge connected to each TPGTeam of the TPGGraph when
+			// initialized.
+			// "maxInitOutgoingEdges" : 3, // Default value
+			"maxInitOutgoingEdges" : 3,
+			// Maximum number of outgoing edge during TPGGraph mutations.
+			// "maxOutgoingEdges" : 5, // Default value
+			"maxOutgoingEdges" : 5,
+			// Number of TPGAction vertex of the initialized TPGGraph.
+			// This parameter is generally automatically set by the LearningEnvironment.
+			// /* "nbActions" : 0,*/ // Commented by default
+			/* "nbActions" : 0,*/
+			// Number of root TPGTeams to maintain when populating the TPGGraph
+			// "nbRoots" : 100, // Default value
+			"nbRoots" : 500,
+			// Probability of adding an outgoing Edge to a Team.
+			// "pEdgeAddition" : 0.7, // Default value
+			"pEdgeAddition" : 0.7,
+			// Probability of deleting an outgoing Edge of a Team.
+			// "pEdgeDeletion" : 0.7, // Default value
+			"pEdgeDeletion" : 0.7,
+			// Probability of changing the destination of an Edge.
+			// "pEdgeDestinationChange" : 0.1, // Default value
+			"pEdgeDestinationChange" : 0.1,
+			// Probability of the new destination of an Edge to be an Action.
+			// "pEdgeDestinationIsAction" : 0.5, // Default value
+			"pEdgeDestinationIsAction" : 0.5,
+			// Probability of mutating the Program of an outgoing Edge.
+			// "pProgramMutation" : 0.2, // Default value
+			"pProgramMutation" : 0.2
+		}
+	},
+	// Number of generations of the training.
+	// "nbGenerations" : 500, // Default value
+	"nbGenerations" : 200,
+	// [Only used in AdversarialLearningAgent.]
+	// Number of times each job is evaluated in the learning process.
+	// Each root may belong to several jobs, hence this parameter should be lower
+	// than the nbIterationsPerPolicyEvaluation parameter.
+	// "nbIterationsPerJob" : 1, // Default value
+	"nbIterationsPerJob" : 1,
+	// Number of evaluation of each root per generation.
+	// "nbIterationsPerPolicyEvaluation" : 5, // Default value
+	"nbIterationsPerPolicyEvaluation" : 1,
+	// Number of Constant available in each Program.
+	// "nbProgramConstant" : 0, // Default value
+	"nbProgramConstant" : 5,
+	// Number of registers for the Program execution.
+	// "nbRegisters" : 8, // Default value
+	"nbRegisters" : 8,
+	// [Only used in ParallelLearningAgent and child classes.]
+	// Number of threads used for the training process.
+	// When undefined in the json file, this parameter is automatically set to the
+	// number of cores of the CPU.
+	// /* "nbThreads" : 0,*/ // Commented by default
+	/* "nbThreads" : 0,*/ 
+	// Percentage of deleted (and regenerated) root TPGVertex at each generation.
+	// "ratioDeletedRoots" : 0.5, // Default value
+	"ratioDeletedRoots" : 0.9
 }

--- a/mnist/params.json
+++ b/mnist/params.json
@@ -7,7 +7,7 @@
   "nbGenerations": 200,
   "nbIterationsPerPolicyEvaluation": 1,
   "nbIterationsPerJob": 1,
-  "nbProgramConstant": 0,
+  "nbProgramConstant": 5,
   "nbRegisters": 8,
   "ratioDeletedRoots": 0.90,
 

--- a/mnist/src/main.cpp
+++ b/mnist/src/main.cpp
@@ -51,6 +51,7 @@ int main() {
 	auto max = [](double a, double b)->double {return std::max(a, b); };
 	auto ln = [](double a)->double {return std::log(a); };
 	auto exp = [](double a)->double {return std::exp(a); };
+	auto multByConst = [](double a, Data::Constant c)->double {return a * (double)c / 10.0; };
 	auto sobelMagn = [](const double a[3][3])->double {
 		double result = 0.0;
 		double gx =
@@ -82,6 +83,7 @@ int main() {
 	set.add(*(new Instructions::LambdaInstruction<double, double>(max)));
 	set.add(*(new Instructions::LambdaInstruction<double>(exp)));
 	set.add(*(new Instructions::LambdaInstruction<double>(ln)));
+	set.add(*(new Instructions::LambdaInstruction<double, Data::Constant>(multByConst)));
 	set.add(*(new Instructions::LambdaInstruction<const double[3][3]>(sobelMagn)));
 	set.add(*(new Instructions::LambdaInstruction<const double[3][3]>(sobelDir)));
 
@@ -94,7 +96,6 @@ int main() {
 #ifdef NB_GENERATIONS
 	params.nbGenerations = NB_GENERATIONS;
 #endif // !NB_GENERATIONS
-
 
 	// Instantiate the LearningEnvironment
 	MNIST mnistLE;

--- a/mnist/src/main.cpp
+++ b/mnist/src/main.cpp
@@ -152,6 +152,11 @@ int main() {
 
 	// Keep best policy
 	la.keepBestPolicy();
+
+	// Clear introns instructions
+	la.getTPGGraph().clearProgramIntrons();
+
+	// Export the graph
 	dotExporter.setNewFilePath("out_best.dot");
 	dotExporter.print();
 

--- a/mnist/src/main.cpp
+++ b/mnist/src/main.cpp
@@ -130,6 +130,11 @@ int main() {
 	stats.open("bestPolicyStats.md");
 	Log::LAPolicyStatsLogger logStats(la, stats);
 
+	// Export parameters before starting training.
+	// These may differ from imported parameters because of LE or machine specific
+	// settings such as thread count of number of actions.
+	File::ParametersParser::writeParametersToJson("exported_params.json", params);
+
 	// Train for NB_GENERATIONS generations
 	for (int i = 0; i < params.nbGenerations && !exitProgram; i++) {
 		char buff[13];

--- a/mnist/src/mnist.cpp
+++ b/mnist/src/mnist.cpp
@@ -24,7 +24,7 @@ void MNIST::changeCurrentImage()
 
 	// Load the image in the dataSource
 	for (uint64_t pxlIndex = 0; pxlIndex < 28 * 28; pxlIndex++) {
-		this->currentImage.setDataAt(typeid(double), pxlIndex, dataSource.at(this->currentIndex).at(pxlIndex));
+		this->currentImage.setPointer(&dataSource.at(this->currentIndex));
 	}
 
 	// Keep current label too.

--- a/mnist/src/mnist.h
+++ b/mnist/src/mnist.h
@@ -22,7 +22,7 @@ protected:
 	Mutator::RNG rng;
 
 	/// Current image provided to the LearningAgent
-	Data::PrimitiveTypeArray2D<double> currentImage;
+	Data::Array2DWrapper<double> currentImage;
 
 	/// Current index of the image in the dataset.
 	uint64_t currentIndex;

--- a/pendulum/params.json
+++ b/pendulum/params.json
@@ -1,38 +1,113 @@
 {
-  "archiveSize": 2000,
-  "archivingProbability": 0.01,
-  "doValidation": true,
-  "maxNbActionsPerEval": 1000,
-  "maxNbEvaluationPerPolicy": 10,
-  "nbGenerations": 1200,
-  "nbIterationsPerPolicyEvaluation": 5,
-  "nbIterationsPerJob": 1,
-  "nbProgramConstant": 5,
-  "nbRegisters": 8,
-  "ratioDeletedRoots": 0.998,
-
-  "mutation": {
-    "tpg": {
-      "forceProgramBehaviorChangeOnMutation": true,
-      "maxInitOutgoingEdges": 3,
-      "maxOutgoingEdges": 5,
-      "nbActions": 15,
-      "nbRoots": 2000,
-      "pEdgeAddition": 0.7,
-      "pEdgeDeletion": 0.7,
-      "pEdgeDestinationChange": 0.1,
-      "pEdgeDestinationIsAction": 0.5,
-      "pProgramMutation": 0.2
-    },
-    "prog": {
-      "maxConstValue": 10,
-      "maxProgramSize": 20,
-      "minConstValue": -10,
-      "pAdd": 0.5,
-      "pConstantMutation": 0.5,
-      "pDelete": 0.5,
-      "pMutate": 1.0,
-      "pSwap": 1.0
-    }
-  }
+	// Number of recordings held in the Archive.
+	// "archiveSize" : 50, // Default value
+	"archiveSize" : 2000,
+	// Probability of archiving the result of each Program execution.
+	// "archivingProbability" : 0.05, // Default value
+	"archivingProbability" : 0.01,
+	// Boolean used to activate an evaluation of the surviving roots in validation
+	// mode after the training at each generation.
+	// "doValidation" : false, // Default value
+	"doValidation" : true,
+	// Maximum number of actions performed on the learning environment during the
+	// each evaluation of a root.
+	// "maxNbActionsPerEval" : 1000, // Default value
+	"maxNbActionsPerEval" : 1000,
+	// Maximum number of times a given root is evaluated.After this number is
+	// reached, possibly after several generations, the score of the root will be
+	// fixed, and no further evaluation will be done.
+	// "maxNbEvaluationPerPolicy" : 1000, // Default value
+	"maxNbEvaluationPerPolicy" : 10,
+	"mutation" : 
+	{
+		"prog" : 
+		{
+			// Maximum constant value possible.
+			// "maxConstValue" : 100, // Default value
+			"maxConstValue" : 10,
+			// Maximum number of Line within the Program of the TPG.
+			// "maxProgramSize" : 96, // Default value
+			"maxProgramSize" : 20,
+			// Minimum constant value possible.
+			// "minConstValue" : -10, // Default value
+			"minConstValue" : -10,
+			// Probability of inserting a line in the Program.
+			// "pAdd" : 0.5, // Default value
+			"pAdd" : 0.5,
+			// Probability of each constant to be mutated.
+			// "pConstantMutation" : 0.5, // Default value
+			"pConstantMutation" : 0.5,
+			// Probability of deleting a line of the Program.
+			// "pDelete" : 0.5, // Default value
+			"pDelete" : 0.5,
+			// Probability of altering a line of the Program.
+			// "pMutate" : 1.0, // Default value
+			"pMutate" : 1.0,
+			// Probability of swapping two lines of the Program.
+			// "pSwap" : 1.0, // Default value
+			"pSwap" : 1.0
+		},
+		"tpg" : 
+		{
+			// When a Program is mutated, makes sure its behavior is no longer the same.
+			// "forceProgramBehaviorChangeOnMutation" : false, // Default value
+			"forceProgramBehaviorChangeOnMutation" : true,
+			// Maximum number of TPGEdge connected to each TPGTeam of the TPGGraph when
+			// initialized.
+			// "maxInitOutgoingEdges" : 3, // Default value
+			"maxInitOutgoingEdges" : 3,
+			// Maximum number of outgoing edge during TPGGraph mutations.
+			// "maxOutgoingEdges" : 5, // Default value
+			"maxOutgoingEdges" : 5,
+			// Number of TPGAction vertex of the initialized TPGGraph.
+			// This parameter is generally automatically set by the LearningEnvironment.
+			// /* "nbActions" : 0,*/ // Commented by default
+			/* "nbActions" : 0,*/
+			// Number of root TPGTeams to maintain when populating the TPGGraph
+			// "nbRoots" : 100, // Default value
+			"nbRoots" : 2000,
+			// Probability of adding an outgoing Edge to a Team.
+			// "pEdgeAddition" : 0.7, // Default value
+			"pEdgeAddition" : 0.7,
+			// Probability of deleting an outgoing Edge of a Team.
+			// "pEdgeDeletion" : 0.7, // Default value
+			"pEdgeDeletion" : 0.7,
+			// Probability of changing the destination of an Edge.
+			// "pEdgeDestinationChange" : 0.1, // Default value
+			"pEdgeDestinationChange" : 0.1,
+			// Probability of the new destination of an Edge to be an Action.
+			// "pEdgeDestinationIsAction" : 0.5, // Default value
+			"pEdgeDestinationIsAction" : 0.5,
+			// Probability of mutating the Program of an outgoing Edge.
+			// "pProgramMutation" : 0.2, // Default value
+			"pProgramMutation" : 0.2
+		}
+	},
+	// Number of generations of the training.
+	// "nbGenerations" : 500, // Default value
+	"nbGenerations" : 1200,
+	// [Only used in AdversarialLearningAgent.]
+	// Number of times each job is evaluated in the learning process.
+	// Each root may belong to several jobs, hence this parameter should be lower
+	// than the nbIterationsPerPolicyEvaluation parameter.
+	// "nbIterationsPerJob" : 1, // Default value
+	"nbIterationsPerJob" : 1,
+	// Number of evaluation of each root per generation.
+	// "nbIterationsPerPolicyEvaluation" : 5, // Default value
+	"nbIterationsPerPolicyEvaluation" : 5,
+	// Number of Constant available in each Program.
+	// "nbProgramConstant" : 0, // Default value
+	"nbProgramConstant" : 5,
+	// Number of registers for the Program execution.
+	// "nbRegisters" : 8, // Default value
+	"nbRegisters" : 8,
+	// [Only used in ParallelLearningAgent and child classes.]
+	// Number of threads used for the training process.
+	// When undefined in the json file, this parameter is automatically set to the
+	// number of cores of the CPU.
+	// /* "nbThreads" : 0,*/ // Commented by default
+	/* "nbThreads" : 0,*/
+	// Percentage of deleted (and regenerated) root TPGVertex at each generation.
+	// "ratioDeletedRoots" : 0.5, // Default value
+	"ratioDeletedRoots" : 0.998
 }

--- a/pendulum/src/main.cpp
+++ b/pendulum/src/main.cpp
@@ -91,6 +91,11 @@ int main() {
 	stats.open("bestPolicyStats.md");
 	Log::LAPolicyStatsLogger policyStatsLogger(la, stats);
 
+	// Export parameters before starting training.
+	// These may differ from imported parameters because of LE or machine specific
+	// settings such as thread count of number of actions.
+	File::ParametersParser::writeParametersToJson("exported_params.json", params);
+
 	// Train for params.nbGenerations generations
 	for (int i = 0; i < params.nbGenerations && !exitProgram; i++) {
 		char buff[13];
@@ -112,6 +117,11 @@ int main() {
 
 	// Keep best policy
 	la.keepBestPolicy();
+
+	// Clear introns instructions
+	la.getTPGGraph().clearProgramIntrons();
+
+	// Export the graph
 	dotExporter.setNewFilePath("out_best.dot");
 	dotExporter.print();
 

--- a/stick-game/params.json
+++ b/stick-game/params.json
@@ -1,39 +1,113 @@
 {
-  "archiveSize": 100,
-  "archivingProbability": 0.01,
-  "doValidation": true,
-  "maxNbActionsPerEval": 11,
-  "maxNbEvaluationPerPolicy": 100,
-  "nbGenerations": 300,
-  "nbIterationsPerPolicyEvaluation": 100,
-  "nbIterationsPerJob": 1,
-  "nbProgramConstant": 0,
-  "nbRegisters": 8,
-  "ratioDeletedRoots": 0.5,
-
-  "mutation": {
-    "tpg": {
-      "forceProgramBehaviorChangeOnMutation": true,
-      "maxInitOutgoingEdges": 3,
-      "maxOutgoingEdges": 5,
-      "nbActions": 3,
-      "nbRoots": 1000,
-      "pEdgeAddition": 0.7,
-      "pEdgeDeletion": 0.7,
-      "pEdgeDestinationChange": 0.1,
-      "pEdgeDestinationIsAction": 0.5,
-      "pProgramMutation": 0.2
-    },
-
-    "prog": {
-      "maxConstValue": 10,
-      "maxProgramSize": 20,
-      "minConstValue": -10,
-      "pAdd": 0.5,
-      "pConstantMutation": 0.5,
-      "pDelete": 0.5,
-      "pMutate": 1.0,
-      "pSwap": 1.0
-    }
-  }
+	// Number of recordings held in the Archive.
+	// "archiveSize" : 50, // Default value
+	"archiveSize" : 100,
+	// Probability of archiving the result of each Program execution.
+	// "archivingProbability" : 0.05, // Default value
+	"archivingProbability" : 0.01,
+	// Boolean used to activate an evaluation of the surviving roots in validation
+	// mode after the training at each generation.
+	// "doValidation" : false, // Default value
+	"doValidation" : true,
+	// Maximum number of actions performed on the learning environment during the
+	// each evaluation of a root.
+	// "maxNbActionsPerEval" : 1000, // Default value
+	"maxNbActionsPerEval" : 11,
+	// Maximum number of times a given root is evaluated.After this number is
+	// reached, possibly after several generations, the score of the root will be
+	// fixed, and no further evaluation will be done.
+	// "maxNbEvaluationPerPolicy" : 1000, // Default value
+	"maxNbEvaluationPerPolicy" : 100,
+	"mutation" : 
+	{
+		"prog" : 
+		{
+			// Maximum constant value possible.
+			// "maxConstValue" : 100, // Default value
+			"maxConstValue" : 10,
+			// Maximum number of Line within the Program of the TPG.
+			// "maxProgramSize" : 96, // Default value
+			"maxProgramSize" : 20,
+			// Minimum constant value possible.
+			// "minConstValue" : -10, // Default value
+			"minConstValue" : -10,
+			// Probability of inserting a line in the Program.
+			// "pAdd" : 0.5, // Default value
+			"pAdd" : 0.5,
+			// Probability of each constant to be mutated.
+			// "pConstantMutation" : 0.5, // Default value
+			"pConstantMutation" : 0.5,
+			// Probability of deleting a line of the Program.
+			// "pDelete" : 0.5, // Default value
+			"pDelete" : 0.5,
+			// Probability of altering a line of the Program.
+			// "pMutate" : 1.0, // Default value
+			"pMutate" : 1.0,
+			// Probability of swapping two lines of the Program.
+			// "pSwap" : 1.0, // Default value
+			"pSwap" : 1.0
+		},
+		"tpg" : 
+		{
+			// When a Program is mutated, makes sure its behavior is no longer the same.
+			// "forceProgramBehaviorChangeOnMutation" : false, // Default value
+			"forceProgramBehaviorChangeOnMutation" : true,
+			// Maximum number of TPGEdge connected to each TPGTeam of the TPGGraph when
+			// initialized.
+			// "maxInitOutgoingEdges" : 3, // Default value
+			"maxInitOutgoingEdges" : 3,
+			// Maximum number of outgoing edge during TPGGraph mutations.
+			// "maxOutgoingEdges" : 5, // Default value
+			"maxOutgoingEdges" : 5,
+			// Number of TPGAction vertex of the initialized TPGGraph.
+			// This parameter is generally automatically set by the LearningEnvironment.
+			// /* "nbActions" : 0,*/ // Commented by default
+			/* "nbActions" : 0,*/
+			// Number of root TPGTeams to maintain when populating the TPGGraph
+			// "nbRoots" : 100, // Default value
+			"nbRoots" : 1000,
+			// Probability of adding an outgoing Edge to a Team.
+			// "pEdgeAddition" : 0.7, // Default value
+			"pEdgeAddition" : 0.7,
+			// Probability of deleting an outgoing Edge of a Team.
+			// "pEdgeDeletion" : 0.7, // Default value
+			"pEdgeDeletion" : 0.7,
+			// Probability of changing the destination of an Edge.
+			// "pEdgeDestinationChange" : 0.1, // Default value
+			"pEdgeDestinationChange" : 0.1,
+			// Probability of the new destination of an Edge to be an Action.
+			// "pEdgeDestinationIsAction" : 0.5, // Default value
+			"pEdgeDestinationIsAction" : 0.5,
+			// Probability of mutating the Program of an outgoing Edge.
+			// "pProgramMutation" : 0.2, // Default value
+			"pProgramMutation" : 0.2
+		}
+	},
+	// Number of generations of the training.
+	// "nbGenerations" : 500, // Default value
+	"nbGenerations" : 10,
+	// [Only used in AdversarialLearningAgent.]
+	// Number of times each job is evaluated in the learning process.
+	// Each root may belong to several jobs, hence this parameter should be lower
+	// than the nbIterationsPerPolicyEvaluation parameter.
+	// "nbIterationsPerJob" : 1, // Default value
+	"nbIterationsPerJob" : 1,
+	// Number of evaluation of each root per generation.
+	// "nbIterationsPerPolicyEvaluation" : 5, // Default value
+	"nbIterationsPerPolicyEvaluation" : 100,
+	// Number of Constant available in each Program.
+	// "nbProgramConstant" : 0, // Default value
+	"nbProgramConstant" : 0,
+	// Number of registers for the Program execution.
+	// "nbRegisters" : 8, // Default value
+	"nbRegisters" : 8,
+	// [Only used in ParallelLearningAgent and child classes.]
+	// Number of threads used for the training process.
+	// When undefined in the json file, this parameter is automatically set to the
+	// number of cores of the CPU.
+	// /* "nbThreads" : 0,*/ // Commented by default
+	/* "nbThreads" : 0,*/
+	// Percentage of deleted (and regenerated) root TPGVertex at each generation.
+	// "ratioDeletedRoots" : 0.5, // Default value
+	"ratioDeletedRoots" : 0.5
 }

--- a/tic-tac-toe/params.json
+++ b/tic-tac-toe/params.json
@@ -1,38 +1,113 @@
 {
-  "archiveSize": 50,
-  "archivingProbability": 0.05,
-  "doValidation": true,
-  "maxNbActionsPerEval": 5,
-  "maxNbEvaluationPerPolicy": 100000,
-  "nbGenerations": 200,
-  "nbIterationsPerJob": 3,
-  "nbIterationsPerPolicyEvaluation": 10,
-  "nbRegisters": 8,
-  "nbThreads": 6,
-  "ratioDeletedRoots": 0.97,
-
-  "mutation": {
-    "tpg": {
-      "forceProgramBehaviorChangeOnMutation": true,
-      "maxInitOutgoingEdges": 3,
-      "maxOutgoingEdges": 60,
-      "nbActions": 9,
-      "nbRoots": 100,
-      "pEdgeAddition": 0.8,
-      "pEdgeDeletion": 0.8,
-      "pEdgeDestinationChange": 0.3,
-      "pEdgeDestinationIsAction": 0.6,
-      "pProgramMutation": 0.8
-    },
-    "prog": {
-      "maxConstValue": 10,
-      "maxProgramSize": 40,
-      "minConstValue": -10,
-      "pAdd": 0.7,
-      "pConstantMutation": 0.5,
-      "pDelete": 0.7,
-      "pMutate": 1.0,
-      "pSwap": 1.0
-    }
-  }
+	// Number of recordings held in the Archive.
+	// "archiveSize" : 50, // Default value
+	"archiveSize" : 50,
+	// Probability of archiving the result of each Program execution.
+	// "archivingProbability" : 0.05, // Default value
+	"archivingProbability" : 0.05,
+	// Boolean used to activate an evaluation of the surviving roots in validation
+	// mode after the training at each generation.
+	// "doValidation" : false, // Default value
+	"doValidation" : true,
+	// Maximum number of actions performed on the learning environment during the
+	// each evaluation of a root.
+	// "maxNbActionsPerEval" : 1000, // Default value
+	"maxNbActionsPerEval" : 5,
+	// Maximum number of times a given root is evaluated.After this number is
+	// reached, possibly after several generations, the score of the root will be
+	// fixed, and no further evaluation will be done.
+	// "maxNbEvaluationPerPolicy" : 1000, // Default value
+	"maxNbEvaluationPerPolicy" : 100000,
+	"mutation" : 
+	{
+		"prog" : 
+		{
+			// Maximum constant value possible.
+			// "maxConstValue" : 100, // Default value
+			"maxConstValue" : 10,
+			// Maximum number of Line within the Program of the TPG.
+			// "maxProgramSize" : 96, // Default value
+			"maxProgramSize" : 40,
+			// Minimum constant value possible.
+			// "minConstValue" : -10, // Default value
+			"minConstValue" : -10,
+			// Probability of inserting a line in the Program.
+			// "pAdd" : 0.5, // Default value
+			"pAdd" : 0.7,
+			// Probability of each constant to be mutated.
+			// "pConstantMutation" : 0.5, // Default value
+			"pConstantMutation" : 0.5,
+			// Probability of deleting a line of the Program.
+			// "pDelete" : 0.5, // Default value
+			"pDelete" : 0.7,
+			// Probability of altering a line of the Program.
+			// "pMutate" : 1.0, // Default value
+			"pMutate" : 1.0,
+			// Probability of swapping two lines of the Program.
+			// "pSwap" : 1.0, // Default value
+			"pSwap" : 1.0
+		},
+		"tpg" : 
+		{
+			// When a Program is mutated, makes sure its behavior is no longer the same.
+			// "forceProgramBehaviorChangeOnMutation" : false, // Default value
+			"forceProgramBehaviorChangeOnMutation" : true,
+			// Maximum number of TPGEdge connected to each TPGTeam of the TPGGraph when
+			// initialized.
+			// "maxInitOutgoingEdges" : 3, // Default value
+			"maxInitOutgoingEdges" : 3,
+			// Maximum number of outgoing edge during TPGGraph mutations.
+			// "maxOutgoingEdges" : 5, // Default value
+			"maxOutgoingEdges" : 60,
+			// Number of TPGAction vertex of the initialized TPGGraph.
+			// This parameter is generally automatically set by the LearningEnvironment.
+			// /* "nbActions" : 0,*/ // Commented by default
+			/* "nbActions" : 0,*/
+			// Number of root TPGTeams to maintain when populating the TPGGraph
+			// "nbRoots" : 100, // Default value
+			"nbRoots" : 100,
+			// Probability of adding an outgoing Edge to a Team.
+			// "pEdgeAddition" : 0.7, // Default value
+			"pEdgeAddition" : 0.8,
+			// Probability of deleting an outgoing Edge of a Team.
+			// "pEdgeDeletion" : 0.7, // Default value
+			"pEdgeDeletion" : 0.8,
+			// Probability of changing the destination of an Edge.
+			// "pEdgeDestinationChange" : 0.1, // Default value
+			"pEdgeDestinationChange" : 0.3,
+			// Probability of the new destination of an Edge to be an Action.
+			// "pEdgeDestinationIsAction" : 0.5, // Default value
+			"pEdgeDestinationIsAction" : 0.6,
+			// Probability of mutating the Program of an outgoing Edge.
+			// "pProgramMutation" : 0.2, // Default value
+			"pProgramMutation" : 0.8
+		}
+	},
+	// Number of generations of the training.
+	// "nbGenerations" : 500, // Default value
+	"nbGenerations" : 10,
+	// [Only used in AdversarialLearningAgent.]
+	// Number of times each job is evaluated in the learning process.
+	// Each root may belong to several jobs, hence this parameter should be lower
+	// than the nbIterationsPerPolicyEvaluation parameter.
+	// "nbIterationsPerJob" : 1, // Default value
+	"nbIterationsPerJob" : 3,
+	// Number of evaluation of each root per generation.
+	// "nbIterationsPerPolicyEvaluation" : 5, // Default value
+	"nbIterationsPerPolicyEvaluation" : 10,
+	// Number of Constant available in each Program.
+	// "nbProgramConstant" : 0, // Default value
+	"nbProgramConstant" : 0,
+	// Number of registers for the Program execution.
+	// "nbRegisters" : 8, // Default value
+	"nbRegisters" : 8,
+	// [Only used in ParallelLearningAgent and child classes.]
+	// Number of threads used for the training process.
+	// When undefined in the json file, this parameter is automatically set to the
+	// number of cores of the CPU.
+	// /* "nbThreads" : 0,*/ // Commented by default
+	/* "nbThreads" : 0,*/
+	// Percentage of deleted (and regenerated) root TPGVertex at each generation.
+	// "ratioDeletedRoots" : 0.5, // Default value
+	"ratioDeletedRoots" : 0.97
 }

--- a/tic-tac-toe/src/main.cpp
+++ b/tic-tac-toe/src/main.cpp
@@ -103,6 +103,9 @@ int main() {
 	bestStats << ps;
 	bestStats.close();
 
+	// close log file also
+	stats.close();
+
 	// cleanup
 	for (unsigned int i = 0; i < set.getNbInstructions(); i++) {
 		delete (&set.getInstruction(i));

--- a/tic-tac-toe/src/main.cpp
+++ b/tic-tac-toe/src/main.cpp
@@ -63,7 +63,15 @@ int main() {
 	// Create an exporter for all graphs
 	File::TPGGraphDotExporter dotExporter("out_000.dot", la.getTPGGraph());
 
+	// File for printing best policy stat.
+	std::ofstream stats;
+	stats.open("bestPolicyStats.md");
+	Log::LAPolicyStatsLogger logStats(la, stats);
 
+	// Export parameters before starting training.
+	// These may differ from imported parameters because of LE or machine specific
+	// settings such as thread count of number of actions.
+	File::ParametersParser::writeParametersToJson("exported_params.json", params);
 
 	// Train for NB_GENERATIONS generations
 	for (int i = 0; i < params.nbGenerations; i++) {
@@ -79,10 +87,21 @@ int main() {
 
 	// Keep best policy
 	la.keepBestPolicy();
+
+	// Clear introns instructions
+	la.getTPGGraph().clearProgramIntrons();
+
+	// Export the graph
 	dotExporter.setNewFilePath("out_best.dot");
 	dotExporter.print();
 
-
+	TPG::PolicyStats ps;
+	ps.setEnvironment(la.getTPGGraph().getEnvironment());
+	ps.analyzePolicy(la.getBestRoot().first);
+	std::ofstream bestStats;
+	bestStats.open("out_best_stats.md");
+	bestStats << ps;
+	bestStats.close();
 
 	// cleanup
 	for (unsigned int i = 0; i < set.getNbInstructions(); i++) {


### PR DESCRIPTION
Update demo applications with features from gegelatilib v0.6.0.
Includes: 
* Export of parameters into `exported_params.json`
* Update of `params.json` files to contain comments
* Use of `Data::Array2DWrapper` class in MNIST (instead of `Data::PrimitiveDataArray2D`)